### PR TITLE
Fix typo in rpart.Rd

### DIFF
--- a/man/rpart.Rd
+++ b/man/rpart.Rd
@@ -13,7 +13,7 @@ rpart(formula, data, weights, subset, na.action = na.rpart, method,
 }
 \arguments{
   \item{formula}{a \link{formula}, with a response but no interaction
-    terms.  If this a a data frome, that is taken as the model frame
+    terms.  If this a a data frame, that is taken as the model frame
     (see \code{\link{model.frame}).}
   }
   


### PR DESCRIPTION
In the "arguments" section, "formula" argument: changed "If this is a data frome" to "frame"
